### PR TITLE
removed double measurement

### DIFF
--- a/src/quantum.py
+++ b/src/quantum.py
@@ -70,7 +70,7 @@ def collapse_three_states(set_blocks):
 
     # apply second Hadamard if the measurement outcome is 0
     qc.h(1).c_if(c, 2 if set_blocks.index(None) == 1 else 1)
-    qc.measure(q, c)
+    qc.measure(q[1], c[1])
 
     result_state = list(execute(qc, Aer.get_backend('qasm_simulator'), shots=1).result().get_counts(qc).keys())[0]
 


### PR DESCRIPTION
First of all thanks for sharing this cool project. I have a small suggestion/improvement to share.

In the following code, the first `measure(q,c) collapses the qubit 0, and that does not change in its value anymore. Only the qubit 1 could change because of the conditional h(1) gate, thus I suggest replacing the generalized second measurement applied on the whole register with one targeted to the only qubit that could have changes, namely qubit 1. See the suggested changes. 

```python
def collapse_three_states(set_blocks):
    q = QuantumRegister(2)
    c = ClassicalRegister(2)
    qc = QuantumCircuit(q, c)

    if set_blocks.index(None) == 1:
        qc.x(1)
    # apply first Hadamard
    qc.h(0)
    qc.measure(q, c)

    # apply second Hadamard if the measurement outcome is 0
    qc.h(1).c_if(c, 2 if set_blocks.index(None) == 1 else 1)
    qc.measure(q, c)

    result_state = list(execute(qc, Aer.get_backend('qasm_simulator'), shots=1).result().get_counts(qc).keys())[0]

    print(quantum_states[result_state])
    return quantum_states[result_state]
```

Thanks in advance I wish you a happy and productive day ahead